### PR TITLE
Parse data to JSON instead of outputting a JSON object

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -9,4 +9,9 @@ return [
     'data-providers' => [
         // ExampleDataProvider::class,
     ],
+
+    /**
+     * Indicates if the dataset should be removed from the DOM after it has been parsed
+     */
+    'remove-data' => true,
 ];

--- a/resources/views/script.blade.php
+++ b/resources/views/script.blade.php
@@ -1,3 +1,15 @@
-<script>
-    window.{{ config('js-store.window-element') }} = @json(frontend_store()->data());
+@php
+    $rand = Str::random();
+@endphp
+
+<script
+    id="laravel-js-store-{{ $rand }}"
+    data-store="{{ json_encode(frontend_store()->data()) }}"
+>
+    var el = document.getElementById('laravel-js-store-{{ $rand }}')
+    window.{{ config('js-store.window-element') }} = JSON.parse(el.dataset.store)
+
+@if(config('js-store.remove-data', true))
+    delete el.dataset.store
+@endif
 </script>


### PR DESCRIPTION
The data object is parsed to json with `JSON.parse()` instead of outputting the JS object on the page. 

See [The cost of parsing JSON](https://v8.dev/blog/cost-of-javascript-2019#json) for more info