### PR TITLE
Add test suite + update Laravel versions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,8 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: [7.1, 7.2, 7.3, 7.4, 8.0]
-        laravel: [5.8.*, 6.*, 7.*, 8.*]
+        php: [7.2, 7.3, 7.4, 8.0]
+        laravel: [6.*, 7.*, 8.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 8.*
@@ -20,19 +20,9 @@ jobs:
             testbench: 5.*
           - laravel: 6.*
             testbench: 4.*
-          - laravel: 5.8.*
-            testbench: 3.8.*
         exclude:
           - laravel: 8.*
-            php: 7.1
-          - laravel: 8.*
             php: 7.2
-          - laravel: 7.*
-            php: 7.1
-          - laravel: 6.*
-            php: 7.1
-          - laravel: 5.8.*
-            php: 8.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,62 @@
+name: run-tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        php: [7.1, 7.2, 7.3, 7.4, 8.0]
+        laravel: [5.8.*, 6.*, 7.*, 8.*]
+        dependency-version: [prefer-lowest, prefer-stable]
+        include:
+          - laravel: 8.*
+            testbench: 6.*
+          - laravel: 7.*
+            testbench: 5.*
+          - laravel: 6.*
+            testbench: 4.*
+          - laravel: 5.8.*
+            testbench: 3.8.*
+        exclude:
+          - laravel: 8.*
+            php: 7.1
+          - laravel: 8.*
+            php: 7.2
+          - laravel: 7.*
+            php: 7.1
+          - laravel: 6.*
+            php: 7.1
+          - laravel: 5.8.*
+            php: 8.0
+
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Cache dependencies
+        uses: actions/cache@v1
+        with:
+          path: ~/.composer/cache/files
+          key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: json
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+
+      - name: Execute tests
+        run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
         }
     ],
     "require": {
-        "php": "^7.1|^8.0",
+        "php": "^7.2|^8.0",
         "ext-json": "*",
-        "illuminate/support": "~5.8.0|^6.0|^7.0|^8.0"
+        "illuminate/support": "^6.0|^7.0|^8.0"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.8.0|^4.0|^5.0|^6.0",
+        "orchestra/testbench": "^4.0|^5.0|^6.0",
         "phpunit/phpunit": "^7.0|^8.0",
         "squizlabs/php_codesniffer": "^3.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.1|^8.0",
         "ext-json": "*",
-        "illuminate/support": "5.8.*|6.*"
+        "illuminate/support": "~5.8.0|^6.0|^7.0|^8.0"
     },
     "require-dev": {
-        "orchestra/testbench": "3.8.*|4.*",
+        "orchestra/testbench": "~3.8.0|^4.0|^5.0|^6.0",
         "phpunit/phpunit": "^7.0|^8.0",
         "squizlabs/php_codesniffer": "^3.4"
     },


### PR DESCRIPTION
Adds test suite for supported Laravel and PHP versions

Dropped support for Laravel 5.8.* and PHP 7.1. PHP 7.2 could also be dropped, see [PHP.net - Supported Versions](https://www.php.net/supported-versions.php), but Laravel 6.x and 7.x still support this version.