### PR TITLE
View and Response macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,26 @@ frontend_store()->put('user', Auth::user());
 // Using the laravel container
 app()->make(\HiHaHo\LaravelJsStore\Store::class)->put('user', Auth::user());
 app()->make('js-store')->put('user', Auth::user());
+
+// Using the view or response macro
+class Controller
+{
+    public function index()
+    {
+        return view('index')
+            ->js('foo', 'bar');
+    }
+
+    public function create()
+    {
+        return response()
+            ->view('create')
+            ->js([
+                'foo' => 'Fred',
+                'bar' => 'Waldo',
+            ]);
+    }
+}
 ```
 
 ### Data-providers

--- a/src/Exceptions/InvalidResponseException.php
+++ b/src/Exceptions/InvalidResponseException.php
@@ -1,0 +1,11 @@
+<?php
+
+
+namespace HiHaHo\LaravelJsStore\Exceptions;
+
+use Exception;
+
+class InvalidResponseException extends Exception
+{
+
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -3,9 +3,11 @@
 namespace HiHaHo\LaravelJsStore;
 
 use HiHaHo\LaravelJsStore\Console\MakeFrontendDataProviderCommand;
-use Illuminate\Support\Collection;
+use HiHaHo\LaravelJsStore\Exceptions\InvalidResponseException;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
+use Illuminate\View\View;
 
 class ServiceProvider extends BaseServiceProvider
 {
@@ -19,6 +21,26 @@ class ServiceProvider extends BaseServiceProvider
         Blade::include('js-store::script', 'frontend_store');
 
         $this->bindDataProviders();
+
+        View::macro('js', function ($key, $value = null) {
+            $data = is_array($key) ? $key : [$key => $value];
+
+            app(Store::class)->merge($data);
+
+            return $this;
+        });
+
+        Response::macro('js', function ($key, $value = null) {
+            if (! $this->getOriginalContent() instanceof View) {
+                throw new InvalidResponseException('Some error');
+            }
+
+            $data = is_array($key) ? $key : [$key => $value];
+
+            app(Store::class)->merge($data);
+
+            return $this;
+        });
 
         if ($this->app->runningInConsole()) {
             $this->publishes([

--- a/src/Store.php
+++ b/src/Store.php
@@ -23,6 +23,13 @@ class Store implements Jsonable, Arrayable
         return $this;
     }
 
+    public function merge(array $data): self
+    {
+        $this->data = $this->data->merge($data);
+
+        return $this;
+    }
+
     public function data(): Collection
     {
         return $this->data;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,6 +7,7 @@ namespace HiHaHo\LaravelJsStore\Tests;
 use HiHaHo\LaravelJsStore\ServiceProvider;
 use HiHaHo\LaravelJsStore\Store;
 use HiHaHo\LaravelJsStore\Tests\stubs\ValidDataProvider;
+use Illuminate\Support\Facades\View;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 
 class TestCase extends BaseTestCase
@@ -26,6 +27,8 @@ class TestCase extends BaseTestCase
         parent::setUp();
 
         $this->store = $this->app->make(Store::class);
+
+        View::addLocation(__DIR__.'/stubs/views');
     }
 
     /**

--- a/tests/stubs/views/index.blade.php
+++ b/tests/stubs/views/index.blade.php
@@ -1,0 +1,8 @@
+<html>
+    <head>
+        
+    </head>
+    <body>
+        @frontend_store
+    </body>
+</html>


### PR DESCRIPTION
This adds a macro to push data to the js-store through a view or response instead of on a separate line using the helper or facade.

```php
class Controller
{
    public function index()
    {
        return view('index')
            ->js('foo', 'bar');
    }

    public function create()
    {
        return response()
            ->view('create')
            ->js([
                'foo' => 'Fred',
                'bar' => 'Waldo',
            ]);
    }
}
```