### PR TITLE
Add support for Laravel 9

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,9 +11,11 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [7.4, 8.0]
-        laravel: [^7.2, ^8.0]
+        laravel: [^7.2, ^8.0, ^9.0]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
+          - laravel: ^9.0
+            testbench: 7.*
           - laravel: ^8.0
             testbench: 6.*
           - laravel: ^7.2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,6 +20,9 @@ jobs:
             testbench: 6.*
           - laravel: ^7.2
             testbench: 5.*
+        exclude:
+            - laravel: ^9.0
+              php: 7.4
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to `laravel-js-store` will be documented in this file
 
+## 2.1.0 - 2022-08-07
+- Add support for Laravel 9
+
 ## 2.0.1 - 2021-07-01
 - Fix PrepareStoreForNextOperation and update notes about Octane
 

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
     "require": {
         "php": "^7.4|^8.0",
         "ext-json": "*",
-        "illuminate/support": "^7.2|^8.0",
+        "illuminate/support": "^7.2|^8.0|^9.0",
         "spatie/laravel-package-tools": "^1.1"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.0|^6.0",
+        "orchestra/testbench": "^5.0|^6.0|^7.0",
         "phpunit/phpunit": "^8.0|^9.0",
         "squizlabs/php_codesniffer": "^3.4"
     },

--- a/tests/MakeFrontendDataProviderTest.php
+++ b/tests/MakeFrontendDataProviderTest.php
@@ -20,10 +20,17 @@ class MakeFrontendDataProviderCommandTest extends TestCase
 
         $this->assertFalse(File::exists($provider));
 
-        $this->artisan('make:frontend-data-provider', ['name' => 'Test'])
-            ->expectsOutputToContain('FrontendDataProvider created successfully.')
+        $command = $this->artisan('make:frontend-data-provider', ['name' => 'Test'])
             ->expectsConfirmation("Generated key: $key, would you like to use a custom key?")
             ->assertExitCode(0);
+
+        if (method_exists($command, 'expectsOutputToContain')) {
+            $command->expectsOutputToContain('FrontendDataProvider created successfully.');
+        } else {
+            $command->expectsOutput('FrontendDataProvider created successfully.');
+        }
+
+        $command->run();
 
         $this->assertTrue(File::exists($provider));
 
@@ -64,13 +71,20 @@ CLASS;
 
         $this->assertFalse(File::exists($provider));
 
-        $this->artisan('make:frontend-data-provider', ['name' => 'Test'])
-            ->expectsOutputToContain('FrontendDataProvider created successfully.')
+        $command = $this->artisan('make:frontend-data-provider', ['name' => 'Test'])
             ->expectsConfirmation("Generated key: $key, would you like to use a custom key?", 'yes')
             ->expectsQuestion('Custom key', '')
             ->assertExitCode(0);
 
-            $this->assertTrue(File::exists($provider));
+        if (method_exists($command, 'expectsOutputToContain')) {
+            $command->expectsOutputToContain('FrontendDataProvider created successfully.');
+        } else {
+            $command->expectsOutput('FrontendDataProvider created successfully.');
+        }
+
+        $command->run();
+
+        $this->assertTrue(File::exists($provider));
 
         $expectedContents = <<<CLASS
 <?php
@@ -111,11 +125,18 @@ CLASS;
 
         $this->assertFalse(File::exists($provider));
 
-        $this->artisan('make:frontend-data-provider', ['name' => 'Test'])
-            ->expectsOutputToContain('FrontendDataProvider created successfully.')
+        $command = $this->artisan('make:frontend-data-provider', ['name' => 'Test'])
             ->expectsConfirmation("Generated key: $key, would you like to use a custom key?", 'yes')
             ->expectsQuestion('Custom key', 'custom-key')
             ->assertExitCode(0);
+
+        if (method_exists($command, 'expectsOutputToContain')) {
+            $command->expectsOutputToContain('FrontendDataProvider created successfully.');
+        } else {
+            $command->expectsOutput('FrontendDataProvider created successfully.');
+        }
+
+        $command->run();
 
         $this->assertTrue(File::exists($provider));
 

--- a/tests/MakeFrontendDataProviderTest.php
+++ b/tests/MakeFrontendDataProviderTest.php
@@ -21,7 +21,7 @@ class MakeFrontendDataProviderCommandTest extends TestCase
         $this->assertFalse(File::exists($provider));
 
         $this->artisan('make:frontend-data-provider', ['name' => 'Test'])
-            ->expectsOutput('FrontendDataProvider created successfully.')
+            ->expectsOutputToContain('FrontendDataProvider created successfully.')
             ->expectsConfirmation("Generated key: $key, would you like to use a custom key?")
             ->assertExitCode(0);
 
@@ -65,7 +65,7 @@ CLASS;
         $this->assertFalse(File::exists($provider));
 
         $this->artisan('make:frontend-data-provider', ['name' => 'Test'])
-            ->expectsOutput('FrontendDataProvider created successfully.')
+            ->expectsOutputToContain('FrontendDataProvider created successfully.')
             ->expectsConfirmation("Generated key: $key, would you like to use a custom key?", 'yes')
             ->expectsQuestion('Custom key', '')
             ->assertExitCode(0);
@@ -112,7 +112,7 @@ CLASS;
         $this->assertFalse(File::exists($provider));
 
         $this->artisan('make:frontend-data-provider', ['name' => 'Test'])
-            ->expectsOutput('FrontendDataProvider created successfully.')
+            ->expectsOutputToContain('FrontendDataProvider created successfully.')
             ->expectsConfirmation("Generated key: $key, would you like to use a custom key?", 'yes')
             ->expectsQuestion('Custom key', 'custom-key')
             ->assertExitCode(0);


### PR DESCRIPTION
Added support for Laravel 9.

Making `tests/MakeFrontendDataProviderTest.php` pass was quite a challange, since Laravel 9 now uses Termwind to render the console output, which adds extra body to the output, resulting in `expectsOutput` to fail. 

`expectsOutputToContain` does pass, but this is not available in older Laravel versions.

To support both Laravel 9 and older versions, I introduced a check to see if `expectsOutputToContain` is available, if so use it, otherwise keep using `expectsOutput`.

Now `$this->artisan()` isn't fluid anymore, we have to store it in a variable, which prevents `__destruct` from being called, which means we have to call the `run` method to actually execute the command