### PR TITLE
[3.1.0] Render store data in the DOM using the @json blade directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to `laravel-js-store` will be documented in this file
 
+## 3.1.0 - 2024-08-01
+- Render store data in the DOM using the @json blade directive
+
 ## 3.0.0 - 2023-03-01
 - Add support for Laravel 10
 - Add support for PHP 8.2

--- a/resources/views/script.blade.php
+++ b/resources/views/script.blade.php
@@ -4,7 +4,7 @@
 
 <script
     id="laravel-js-store-{{ $rand }}"
-    data-store="{{ json_encode(frontend_store()->data()) }}"
+    data-store='@json(frontend_store()->data(), JSON_THROW_ON_ERROR | JSON_HEX_APOS | JSON_HEX_QUOT)'
 >
     var el = document.getElementById('laravel-js-store-{{ $rand }}')
     window.{{ config('js-store.window-element') }} = JSON.parse(el.dataset.store)


### PR DESCRIPTION
Render store data in the DOM using the @json blade directive. This prevents issues when overriding the Blade echo format.