### PR TITLE
Laravel 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,14 +18,16 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.2, 8.3, 8.4]
-        laravel: [^11.31, ^12.0]
+        laravel: [^12.0, ^13.0]
         dependency-version: [prefer-lowest, prefer-stable]
-        testbench: [^9.6, ^10.0]
+        testbench: [^10.0, ^11.0]
         exclude:
-            -   laravel: ^11.31
-                testbench: ^10.0
             -   laravel: ^12.0
-                testbench: ^9.6
+                testbench: ^11.0
+            -   laravel: ^13.0
+                testbench: ^10.0
+            -   laravel: ^13.0
+                php: 8.2
 
     name: PHP${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-js-store` will be documented in this file
 
+## 5.2.0 - 2026-04-01
+* Add support for Laravel 13
+* Drop support for Laravel 11
+
 ## 5.1.0 - 2025-02-25
 * Add support for Laravel 12 by @SanderMuller in https://github.com/hihaho/laravel-js-store/pull/14
 * Update PHPUnit to 11.0

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
     "require": {
         "php": "^8.2",
         "ext-json": "*",
-        "illuminate/support": "^11.31|^12.0",
+        "illuminate/support": "^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.14"
     },
     "require-dev": {
         "laravel/pint": "^1.21",
-        "orchestra/testbench": "^9.6|^10.0",
+        "orchestra/testbench": "^10.0|^11.0",
         "phpunit/phpunit": "^11.5",
         "roave/security-advisories": "dev-latest"
     },

--- a/src/StoreFacade.php
+++ b/src/StoreFacade.php
@@ -5,7 +5,7 @@ namespace HiHaHo\LaravelJsStore;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @see \HiHaHo\LaravelJsStore\Store
+ * @see Store
  */
 class StoreFacade extends Facade
 {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ namespace HiHaHo\LaravelJsStore\Tests;
 use HiHaHo\LaravelJsStore\ServiceProvider;
 use HiHaHo\LaravelJsStore\Store;
 use HiHaHo\LaravelJsStore\Tests\stubs\ValidDataProvider;
+use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\View;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 
@@ -31,7 +32,7 @@ class TestCase extends BaseTestCase
     /**
      * Define environment setup.
      *
-     * @param  \Illuminate\Foundation\Application  $app
+     * @param  Application  $app
      */
     protected function getEnvironmentSetUp($app): void
     {


### PR DESCRIPTION
 ## Summary                                                                                          
  - Add support for Laravel 13                                                                        
  - Drop support for Laravel 11                                                                       
  - Exclude PHP 8.2 from Laravel 13 CI runs (Laravel 13 requires PHP 8.3+)                            
                                                                                                      
  ## Changes                                                                                          
  - Update `illuminate/support` constraint to `^12.0|^13.0`
  - Update `orchestra/testbench` constraint to `^10.0|^11.0`                                          
  - Update CI matrix to test Laravel 12 and 13 with matching testbench versions
  - Add CI exclusion for PHP 8.2 + Laravel 13 (unsupported combination)  